### PR TITLE
Update for 2022.10.01 deployment at NERSC

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ repository to do the installation at a specific `<site>` on a specific `<machine
 It has a number of sub-directories, named by `<site>`.
 Each of those subdirectories contains one or more subdirectories, named by `<machine>`.
 
-Each of those `<site>/<machine>` subdirectories contains three files:
+Each of those `<site>/<machine>` subdirectories contains several files:
 
 - `<machine>.config.yaml`:
 
@@ -24,3 +24,14 @@ Each of those `<site>/<machine>` subdirectories contains three files:
 
   this includes configuration for the software environment, including MPI, CUDA, python, perl, etc.;
   specifies the build-dependency version for installing hpctoolkit
+
+- `<machine>.spack.yaml`:
+
+  this specifies a Spack environment file, which allows building several HPCToolkit configurations
+  with Spack in one go. If present, the `spacklink` script will create a new directory parallel to
+  the Spack repository called `spack-env`. The installation steps then become:
+
+```shell
+  $ spack/bin/spack -e spack-env concretize # add "-f" to re-concretize as needed
+  $ spack/bin/spack -e spack-env install
+```

--- a/bin/buildompt
+++ b/bin/buildompt
@@ -1,0 +1,101 @@
+#!/bin/bash
+
+#-------------------------------------------------------------------------------
+# buildompt
+#
+# A script to build LLVM OpenMP runtime for OMPT support
+#
+# Please provide the following positional arguments:
+#
+# 1. <llvm-repo-srcdir>: source directory of a git clone of the LLVM monorepo.
+#    You can always get the latest dev version using
+#    git clone https://github.com/llvm/llvm-project.git
+#
+# 2. <install-prefix>: the installation prefix to pass on to CMake
+#
+# If not set already, you might want to export CC and CXX to point to
+# the gcc and g++ versions that you want to use.
+#
+# Also check out LLVM docs on building:
+# https://llvm.org/docs/GettingStarted.html#getting-started-with-llvm
+#-------------------------------------------------------------------------------
+
+usage()
+{ 
+  echo "Usage: $(basename $0) [-n] [-j N] <llvm-repo-srcdir> <install-prefix>"
+  exit 1
+}
+
+# -n flag means a dry-run simulation
+if [ "$1" == "-n" ]; then
+  echo=echo
+  shift
+else
+  echo=
+fi
+
+# -j flag specifies to build in parallel with N jobs
+if [ "$1" == "-j" ]; then
+  NJOBS=$2
+  shift 2  
+fi
+
+# $1 LLVM monorepo source directory
+if [ "x$1" == "x" ]; then
+  usage
+else
+  LLVM_SRCDIR="$1"
+fi
+
+# $2 Install prefix directory
+if [ "x$2" == "x" ]; then
+    usage
+else
+  LLVM_OMP_PFX="$2"
+fi  
+
+if [ -d "${LLVM_SRCDIR}" ]; then
+  LLVM_OMP_SRCDIR="${LLVM_SRCDIR}/openmp"
+  LLVM_OMP_BLDDIR="${LLVM_OMP_SRCDIR}/openmp-build"
+  if [ ! -d "${LLVM_OMP_SRCDIR}" ]; then
+    echo "$(basename $0): Cannot find LLVM OpenMP source directory ${LLVM_OMP_SRCDIR}"
+    usage
+  fi
+  if [ -d "${LLVM_OMP_BLDDIR}" ]; then
+    LLVM_OMP_BLDDIR_REAL="$(realpath -m ${LLVM_OMP_BLDDIR})"
+    echo "Deleting previous build directory at ${LLVM_OMP_BLDDIR_REAL}"
+    $echo rm -rf "${LLVM_OMP_BLDDIR_REAL}"
+  fi
+  $echo mkdir -p "${LLVM_OMP_BLDDIR_REAL}"
+fi
+
+# Set up install prefix
+LLVM_OMP_PFX_REAL="$(realpath -m ${LLVM_OMP_PFX})"
+
+$echo pushd "${LLVM_OMP_BLDDIR}"
+
+#-------------------------------------------------------------------------------
+# Configure
+#-------------------------------------------------------------------------------
+
+$echo cmake -D CMAKE_BUILD_TYPE=RelWithDebInfo -D CMAKE_C_COMPILER=$CC -D CMAKE_CXX_COMPILER=$CXX -D LIBOMP_OMPT_SUPPORT=ON -D OPENMP_ENABLE_LIBOMPTARGET=OFF -D CMAKE_INSTALL_PREFIX="${LLVM_OMP_PFX_REAL})" ..
+  if [ $? -ne 0 ]; then
+    echo "$(basename $0): Configure failed!"
+    exit 0  
+  fi
+
+#-------------------------------------------------------------------------------
+# Build
+#-------------------------------------------------------------------------------
+
+  if [ -n "$NJOBS" ]; then
+    $echo make -j $NJOBS install
+  else
+    $echo make install
+  fi
+  if [ $? -ne 0 ]; then
+    echo "$(basename $0): Build failed!"
+    exit 0  
+  fi
+
+$echo popd

--- a/bin/buildompt
+++ b/bin/buildompt
@@ -78,7 +78,7 @@ $echo pushd "${LLVM_OMP_BLDDIR}"
 # Configure
 #-------------------------------------------------------------------------------
 
-$echo cmake -D CMAKE_BUILD_TYPE=RelWithDebInfo -D CMAKE_C_COMPILER=$CC -D CMAKE_CXX_COMPILER=$CXX -D LIBOMP_OMPT_SUPPORT=ON -D OPENMP_ENABLE_LIBOMPTARGET=OFF -D CMAKE_INSTALL_PREFIX="${LLVM_OMP_PFX_REAL})" ..
+$echo cmake -D CMAKE_BUILD_TYPE=RelWithDebInfo -D CMAKE_C_COMPILER=$CC -D CMAKE_CXX_COMPILER=$CXX -D LIBOMP_OMPT_SUPPORT=ON -D OPENMP_ENABLE_LIBOMPTARGET=OFF -D CMAKE_INSTALL_PREFIX="${LLVM_OMP_PFX_REAL}" ..
   if [ $? -ne 0 ]; then
     echo "$(basename $0): Configure failed!"
     exit 0  

--- a/bin/spacklink
+++ b/bin/spacklink
@@ -78,6 +78,7 @@ if test ! -d $spack_config_root/$site/$machine; then
 fi
 
 spack_etc=$spack_root/etc/spack
+spack_env_root="$(realpath $spack_root/../spack-env)"
 
 echo Removing current spack configuration settings
 $echo /bin/rm -rf $spack_etc/*.yaml
@@ -87,6 +88,7 @@ echo "Configuring $spack_root with spack configuration files for  site=$site mac
 config=$spack_config_root/$site/$machine/$machine.config.yaml
 modules=$spack_config_root/$site/$machine/$machine.modules.yaml
 packages=$spack_config_root/$site/$machine/$machine.packages.yaml
+spack_env_yaml=$spack_config_root/$site/$machine/$machine.spack.yaml
 
 if test ! -f $config; then
 	echo "No config file $config; skipping"
@@ -104,4 +106,17 @@ if test ! -f $packages; then
 	$echo "No packages file $packages; skipping"
 else
 	$echo ln  -s $packages $spack_etc/packages.yaml
+fi
+
+if test -f $spack_env_yaml; then
+  echo "Found Spack environment file $spack_env_yaml"
+  if test ! -d "$spack_env_root"; then
+    echo "Creating Spack environment directory at $spack_env_root"
+    $echo mkdir -p "$spack_env_root"
+  fi
+  if test -h "$spack_env_root/spack.yaml"; then
+    echo "Note: remember to reconcretize the Spack environment"
+    $echo /bin/rm -rf "$spack_env_root/spack.yaml"
+  fi  
+  $echo ln -s $spack_env_yaml $spack_env_root/spack.yaml
 fi

--- a/nersc/perlmutter/perlmutter.config.yaml
+++ b/nersc/perlmutter/perlmutter.config.yaml
@@ -1,0 +1,22 @@
+# -------------------------------------------------------------------------
+# This is the per-spack-instance configuration file customized for
+# Perlmutter. Keys that are identical to the defaults have been omitted.
+# Make sure to run bin/spacklink!
+# -------------------------------------------------------------------------
+config:
+  # This is the path to the root of the Spack install tree.
+  install_tree:
+    root: /global/cfs/cdirs/m3977/2022.10.01/perlmutter/spack
+
+
+  # Temporary locations Spack can try to use for builds.
+  # Use PSCRATCH on Perlmutter for best performance.
+  build_stage:
+    - /pscratch/sd/w/wyphan/spack/stage
+
+
+  # How long to wait to lock the Spack installation database. This lock is used
+  # when Spack needs to manage its own package metadata and all operations are
+  # expected to complete within the default time limit. The timeout should
+  # therefore generally be left untouched.
+  db_lock_timeout: 120

--- a/nersc/perlmutter/perlmutter.modules.yaml
+++ b/nersc/perlmutter/perlmutter.modules.yaml
@@ -1,0 +1,33 @@
+# -------------------------------------------------------------------------
+# This is the default configuration for Spack's module file generation.
+#
+# Settings here are versioned with Spack and are intended to provide
+# sensible defaults out of the box. Spack maintainers should edit this
+# file to keep it current.
+#
+# Users can override these settings by editing the following files.
+#
+# Per-spack-instance settings (overrides defaults):
+#   $SPACK_ROOT/etc/spack/modules.yaml
+#
+# Per-user settings (overrides default and site settings):
+#   ~/.spack/modules.yaml
+# -------------------------------------------------------------------------
+modules:
+  default:
+    enable: [lmod]
+    roots:
+      lmod: /global/common/software/m3977/hpctoolkit/2022.10.01/perlmutter/modulefiles
+    arch_folder: false
+    lmod:
+      all:
+        autoload: none
+      core_compilers:
+        - 'gcc@7.5.0'
+      hierarchy: false
+      'hpctoolkit+cuda':
+        projections: '{name}/{version}-gpu'
+	conflict: ['cpu']
+      'hpctoolkit~cuda':
+        projections: '{name}/{version}-cpu'
+	conflict: ['gpu']

--- a/nersc/perlmutter/perlmutter.modules.yaml
+++ b/nersc/perlmutter/perlmutter.modules.yaml
@@ -1,33 +1,28 @@
 # -------------------------------------------------------------------------
-# This is the default configuration for Spack's module file generation.
-#
-# Settings here are versioned with Spack and are intended to provide
-# sensible defaults out of the box. Spack maintainers should edit this
-# file to keep it current.
-#
-# Users can override these settings by editing the following files.
-#
-# Per-spack-instance settings (overrides defaults):
-#   $SPACK_ROOT/etc/spack/modules.yaml
-#
-# Per-user settings (overrides default and site settings):
-#   ~/.spack/modules.yaml
+# This is the per-spack-instance module generator configuration customized
+# for Perlmutter.
+# Make sure to run bin/spacklink!
 # -------------------------------------------------------------------------
 modules:
   default:
     enable: [lmod]
     roots:
-      lmod: /global/common/software/m3977/hpctoolkit/2022.10.01/perlmutter/modulefiles
+      lmod: /global/cfs/cdirs/m3977/2022.10.01/modulefiles
     arch_folder: false
     lmod:
-      all:
-        autoload: none
+      include: ['hpctoolkit', 'hpcviewer']
+      exclude: ['@:']
+      hierarchy: [compiler]
       core_compilers:
         - 'gcc@7.5.0'
-      hierarchy: false
+      hash_length: 0
+      projections:
+        all: '{name}/{version}'
+        'hpctoolkit+cuda': '{name}/{version}-gpu'
+        'hpctoolkit~cuda': '{name}/{version}-cpu'
+      all:
+        autoload: none
       'hpctoolkit+cuda':
-        projections: '{name}/{version}-gpu'
-        conflict: ['cpu']
+        load: ['gpu', 'cudatoolkit/11.7']
       'hpctoolkit~cuda':
-        projections: '{name}/{version}-cpu'
-        conflict: ['gpu']
+        load: ['cpu', 'papi/6.0.0.15']

--- a/nersc/perlmutter/perlmutter.modules.yaml
+++ b/nersc/perlmutter/perlmutter.modules.yaml
@@ -27,7 +27,7 @@ modules:
       hierarchy: false
       'hpctoolkit+cuda':
         projections: '{name}/{version}-gpu'
-	conflict: ['cpu']
+        conflict: ['cpu']
       'hpctoolkit~cuda':
         projections: '{name}/{version}-cpu'
-	conflict: ['gpu']
+        conflict: ['gpu']

--- a/nersc/perlmutter/perlmutter.packages.yaml
+++ b/nersc/perlmutter/perlmutter.packages.yaml
@@ -1,0 +1,404 @@
+#
+#  packages.yaml
+#
+#  This file specifies the versions and variants for HPCToolkit's
+#  dependency packages and serves as a common reference point for how
+#  to build them.  It also specifies the paths or modules for system
+#  build tools (cmake, python, etc) to avoid rebuilding them.
+#
+#  Put this file in one of spack's configuration scope directories,
+#  normally either <spack-root>/etc/spack, or else in its own,
+#  separate directory (and then use 'spack -C dir').
+#
+#  There are two main sections: hpctoolkit dependency specs and system
+#  build tools: cmake, perl, python, MPI and GCC.
+#
+#  See also:
+#    https://spack.readthedocs.io/en/latest/basic_usage.html#specs-dependencies
+#    https://spack.readthedocs.io/en/latest/build_settings.html
+#
+packages:
+
+  #------------------------------------------------------------
+  # For now, HPCToolkit can only be compiled with GCC.
+  # Enforce this requirement here for all Spack packages.
+  #------------------------------------------------------------
+  all:
+    compiler: [gcc@11.2.0]
+
+  #------------------------------------------------------------
+  # 1 -- HPCToolkit Prerequisite Packages
+  #------------------------------------------------------------
+
+  # This section contains hpctoolkit's prerequisites, recommended
+  # versions and necessary variants.  For most packages, the most
+  # recent version will work.
+  #
+  # Note: the following packages have variants that may need changing
+  # for your local system.
+  #
+  #   1. dyninst -- use version 9.3.2 for Blue Gene with the default
+  #   gcc 4.4 compilers.
+  #
+  #   2. intel-tbb -- add '~tm' for AMD, Xeon Phi (KNL, etc), and very
+  #   old Intel systems that don't support transactional memory.
+  #
+  #   3. libmonitor -- add '+bgq' on Blue Gene/Q.
+  #
+  #------------------------------------------------------------
+
+
+  # hpctoolkit -- these settings can be specified here or else on the
+  # spack install command line.
+  #
+  # Use version 'develop' for the latest snapshot from master.
+  #
+  # +mpi builds hpcprof-mpi (requires mpi).
+  # +papi uses papi instead of perfmon.
+  #
+  hpctoolkit:
+    version: [2022.10.01]
+
+
+  # boost -- used by dyninst and now in hpcstruct.
+  #
+  # Dyninst requires >= 1.61.
+  #   1.66.0 is good, works with all dyninst revs.
+  #   1.70.0 requires dyninst >= 10.1.0 (breaks earlier revs).
+  #   1.69.0 requires dyninst >= 10.0.0 (breaks earlier revs).
+  #   1.68.0 breaks the build for hpctoolkit.
+  #
+  # +atomic, +chrono, etc are for dyninst.
+  # +graph, +regex, etc are for toolkit proper.
+  # ~mpi, ~python, etc are to reduce prereqs.
+  # ~debug is to build release (optimized) variant.
+  # visibility=global is required for recent hpctoolkit.
+  #
+  boost:
+    version:  [1.79.0]
+    variants: >
+      +atomic +chrono +date_time +filesystem +system +thread +timer
+      +graph +regex +shared +multithreaded ~debug
+      ~mpi ~python ~iostreams ~numpy
+      visibility=global
+
+  # bzip2 -- used by elfutils to read compressed sections (and copy
+  # libs).
+  #
+  # Bzip2 has resumed development, anything after 1.0.6 is good.
+  #
+  bzip2:
+    version:  [1.0.8]
+    variants: +shared
+
+  # cuda -- Nvidia CUDA
+  #
+  # Version 10.1 reportedly has faster support for PC sampling
+  # Use the default one on Perlmutter
+  #
+  cuda:
+    externals:
+    - spec: cuda@11.7.0
+      modules: [cudatoolkit/11.7]
+    buildable: False
+
+
+  # dyninst -- used in hpcstruct for line map info, inline sequences
+  # and loop analysis.
+  #
+  # Need >= 10.0 or develop for best parseapi and CFG support.  On
+  # Blue Gene, with the default gcc 4.4 compilers, use version 9.3.2.
+  #
+  # +openmp is to support openmp threads in parseapi.
+  #
+  dyninst:
+    version:  [12.2.0]
+    variants: +openmp build_type=RelWithDebInfo
+
+
+  # elfutils -- used by dyninst for reading ELF sections.
+  #
+  # Dyninst requires >= 0.173 and we want a recent version for best
+  # support for output from current compilers.  On Blue Gene, 0.176
+  # doesn't build, so use 0.175.
+  #
+  # +bzip2, +xz are for reading compressed sections.
+  # ~nls is needed to avoid linking with libintl from gettext.
+  #
+  elfutils:
+    version:  [0.186]
+    variants: +bzip2 +xz ~nls
+
+
+  # intel-tbb -- used by dyninst as part of parallel parsing.
+  #
+  # Dyninst requires >= 2018.6 and <= 2020.3
+  #
+  # Note: add ~tm for very old x86 or AMD or KNL systems that don't
+  # support transactional memory (no-op on non-x86).
+  #
+  intel-tbb:
+    version:  [2020.3]
+    variants: +shared ~tm
+
+
+  # intel-xed -- used in various places to parse x86 instructions
+  # (used on x86 only).
+  #
+  # Xed does not have releases, only git repo snapshots.  But Xed
+  # changes pretty slowly.
+  #
+  # +debug adds debug symbols (-g).
+  #
+  intel-xed:
+    version:  [2022.04.17]
+    variants: +debug
+
+
+  # libdwarf -- was used in fnbounds for access to eh frames (not yet
+  # available from elfutils).
+  #
+  # Normally want a recent version for best support for output from
+  # current compilers.
+  #
+  # libdwarf:
+  #   version:  [20180129]
+
+
+  # libiberty -- needed for dyninst configure (although dyninst 10.x
+  # doesn't actually link with it).
+  #
+  # Any recent version is good.
+  # Try to sync the same version with binutils above.
+  #
+  # +pic is needed to link with dyninst shared library.
+  #
+  libiberty:
+    version:  [2.37]
+    variants: +pic
+
+
+  # libmonitor -- used in hpcrun to provide access to an application's
+  # processes and threads.
+  #
+  # Normally want the most recent snapshot.
+  #
+  # +hpctoolkit is needed for features specific to hpctoolkit (client
+  # signals).
+  #
+  # Note: add +bgq on blue gene/q.
+  #
+  libmonitor:
+    version:  [2022.09.02]
+    variants: +hpctoolkit
+
+
+  # libpfm4 (perfmon) -- used in hpcrun for access to the hardware
+  # performance counters.
+  #
+  # If PAPI is available with the perfmon headers, then that
+  # supersedes perfmon.  Otherwise, perfmon provides the perf sample
+  # source but not PAPI.
+  #
+  # Normally want the latest version to support recent CPU types.
+  #
+  libpfm4:
+    version:  [4.11.0]
+
+
+  # libunwind -- used in hpcrun to help with unwinding.
+  #
+  # Normally, we need the most recent snapshot (not the default), or
+  # else develop.
+  #
+  # +xz is for reading compressed symbol tables.
+  #
+  libunwind:
+    version:  [1.6.2]
+    variants: +xz +pic
+
+
+  # mbedtls -- used until hpctoolkit 2022.03.15
+  #
+  # Use a recent version >= 2.16.1.
+  #
+  # +pic is required for linking with hpcrun.
+  #
+  #mbedtls:
+  #  version:  [2.27.0]
+  #  variants: +pic
+
+  # papi -- used in hpcrun for access to the hardware performance
+  # counters.
+  #
+  # If there is a pre-built PAPI for the compute nodes, then it may be
+  # better to use that and replace this with a 'externals:' entry.
+  # But make sure that the PAPI include directory contains the perfmon
+  # headers, or else you can't use both PAPI and perfmon.
+  #
+  # If building, then use version >= 5.6.0 for the installed perfmon
+  # headers.
+  #
+  papi:
+    externals:
+    - spec: papi@6.0.0.15
+      modules: [papi/6.0.0.15]
+    buildable: False
+
+
+  # xerces -- used in hpcprof to read XML.
+  #
+  # Any recent version is good.
+  #
+  # transcoder=iconv is needed to avoid linking with libiconv.
+  #
+  xerces-c:
+    version:  [3.2.3]
+    variants: transcoder=iconv
+
+
+  # xz (lzma) -- used by elfutils and libunwind to read compressed
+  # sections (and copy libs).
+  #
+  # Any recent version is good.
+  #
+  xz:
+    version:  [5.2.5]
+    variants: +pic
+
+
+  # zlib -- used by binutils, elfutils and libdwarf to read compressed
+  # sections (and copy libs).
+  #
+  # Zlib development seems to have resumed with version 1.2.12.
+  # 1.2.9 and 1.2.10 are buggy.
+  #
+  # +optimize is to add -O2.
+  #
+  zlib:
+    version:  [1.2.12]
+    variants: +optimize +shared
+
+
+  #------------------------------------------------------------
+  # 2 -- System Build Tools
+  #------------------------------------------------------------
+
+  # We require cmake >= 3.0, perl >= 5.x and python 2.7.x or 3.x.
+  # There are three ways to satisfy these requirements: a system
+  # installed version (eg, /usr), a module or build from scratch.
+  #
+  # By default, spack will rebuild these, even if your version is
+  # perfectly fine.  If you already have an installed version and
+  # prefer to use that instead, then uncomment some entry below and
+  # edit to fit your system.
+  #
+  # Note: these three are all build tools.  They are needed to build
+  # hpctoolkit, but we don't need them at run time or link with any
+  # libraries.  (Not counting hpcsummary which is a python script.)
+  #
+  #------------------------------------------------------------
+
+
+  # cmake -- dyninst requires cmake >= 3.x.
+
+  # Example for a system install.  This example says that cmake 3.11.0
+  # is available at /usr/bin/cmake.  Note: the 'paths:' entry is the
+  # parent directory of 'bin', not the bin directory itself (similar
+  # to prefix).
+  # cmake:
+  #   externals:
+  #   - spec: cmake@3.11.0:
+  #     prefix: /usr
+  #   buildable: False
+
+  # Example for a module.  This example says that cmake 3.7.2 is
+  # available from module 'CMake/3.7.2'.
+  cmake:
+    externals:
+    - spec: cmake@3.22.0
+      modules: [cmake/3.22.0]
+    buildable: False
+
+  # Example spec to build cmake from scratch.
+  # +ownlibs, ~qt and ~openssl are to reduce prerequisites.
+  # cmake:
+  #   version:  [3.12.4]
+  #   variants: +ownlibs ~qt ~openssl
+
+  #------------------------------------------------------------
+
+  # perl -- autotools requires perl >= 5.x which most systems have.
+
+  # Example for system perl.
+
+  perl:
+    externals:
+    - spec: perl@5.26.1
+      prefix: /usr
+    buildable: False
+
+  # Example spec to build perl.
+  # perl:
+  #   version:  [5.26.2]
+
+  #------------------------------------------------------------
+
+  # python -- spack always requires python >= 2.6 to do anything.
+  # On x86, intel-xed requires python 2.7.x or >= 3.4.
+
+  # Example for system python.
+  python:
+    externals:
+    - spec: python@3.6.15
+      prefix: /usr
+    buildable: False
+
+  # Example for python module.
+  # python:
+  #   externals:
+  #   - spec: python@2.7.15
+  #     modules: [Python/2.7.15]
+  #   buildable: False
+
+  # Example spec to build python.
+  # ~dbm, ~tk are to reduce prerequisites.
+  # python:
+  #   version:  [2.7.15, 3.6.5]
+  #   variants: ~dbm ~tk
+
+  #------------------------------------------------------------
+  # MPI -- hpctoolkit always supports profiling MPI applications.
+  # Adding MPI here is only for building hpcprof-mpi, the MPI version
+  # of hpcprof.
+  #
+  # Normally, you want MPI from a module (mpich, mvapich, openmpi)
+  # that was built for the correct interconnect system for the compute
+  # nodes.  Also, for hpcprof-mpi, MPI should be built with GNU
+  # gcc/g++ and the same version used to build hpctoolkit (to keep the
+  # C++ libraries in sync).
+  #
+
+  cray-mpich:
+    externals:
+    - spec: cray-mpich@8.1.17
+      modules: [cray-mpich/8.1.17]
+    buildable: False
+
+
+  #------------------------------------------------------------
+  # GCC -- hpctoolkit requires building with GNU gcc/g++.  We require
+  # version 4.8 at a minimum and preferably 5.x or later.
+  #
+  # Spack handles compilers specially with the compilers.yaml file.
+  # This example is only for building a more recent compiler.
+  #
+  # Note: spack will select the first version that is compatible with
+  # the rest of the spec and command line.  So, put the version you
+  # want to build first.  4.8.4 is really only for Blue Gene.
+
+  gcc:
+    externals:
+    - spec: gcc@11.2.0 languages=c,c++,fortran
+      modules: [gcc/11.2.0]
+    buildable: False

--- a/nersc/perlmutter/perlmutter.packages.yaml
+++ b/nersc/perlmutter/perlmutter.packages.yaml
@@ -347,19 +347,18 @@ packages:
   # python -- spack always requires python >= 2.6 to do anything.
   # On x86, intel-xed requires python 2.7.x or >= 3.4.
 
-  # Example for system python.
   python:
-    externals:
-    - spec: python@3.6.15
-      prefix: /usr
     buildable: False
+    externals:
+    - spec: python@3.9.12
+      modules: [cray-python/3.9.12.1]
 
-  # Example for python module.
-  # python:
-  #   externals:
-  #   - spec: python@2.7.15
-  #     modules: [Python/2.7.15]
-  #   buildable: False
+  # Note: system Python is affected by issue #25354
+  # https://github.com/spack/spack/issues/25354#issuecomment-958670411
+  #
+  #  - spec: python@3.6.15
+  #    prefix: /usr
+
 
   # Example spec to build python.
   # ~dbm, ~tk are to reduce prerequisites.

--- a/nersc/perlmutter/perlmutter.spack.yaml
+++ b/nersc/perlmutter/perlmutter.spack.yaml
@@ -1,0 +1,12 @@
+# This is a Spack Environment file.
+#
+# It describes a set of packages to be installed, along with
+# configuration settings.
+spack:
+  view: false
+  concretizer:
+    unify: when_possible
+  specs:
+  - matrix:
+    - [hpctoolkit +viewer ~mpi]
+    - [+cuda ~papi, ~cuda +papi]

--- a/src/showopenmp/Makefile
+++ b/src/showopenmp/Makefile
@@ -1,0 +1,12 @@
+all: show tool.so run
+
+run:
+	LD_PRELOAD=./tool.so ./show
+tool.so:
+	gcc -o tool.so -shared -fPIC tool.c
+
+show:
+	gcc -o show -fopenmp show.c
+
+clean:
+	rm -f show tool.so

--- a/src/showopenmp/show.c
+++ b/src/showopenmp/show.c
@@ -1,0 +1,11 @@
+#include <stdio.h>
+#include <omp.h>
+
+int main(int argc, char **argv)
+{
+#pragma omp parallel num_threads(2)
+	{
+	printf("hello world from thread %d\n", omp_get_thread_num());
+	}
+	return 0;
+}

--- a/src/showopenmp/tool.c
+++ b/src/showopenmp/tool.c
@@ -1,0 +1,9 @@
+#include <stdio.h>
+#include <omp.h>
+#include <ompt.h>
+
+ompt_start_tool_result_t *ompt_start_tool(unsigned int omp_version, char **runtime)
+{
+  printf("%s\n", runtime);
+  return 0;
+}


### PR DESCRIPTION
- [x] Perlmutter-GPU
- [x] Perlmutter-CPU
- [x] LLVM OpenMP runtime (for OMPT support)

Note that commit 35ef2cbb6d62f6b0724bb6c2b1f33bf5604452c0 adds rudimentary support for `spack.yaml` [Spack environment files](https://spack.readthedocs.io/en/latest/environments.html). This scheme allows deploying two different Spack variants of HPCToolkit 2022.10.01 at the same time, while reusing all the common dependencies:

1. `hpctoolkit ~mpi +cuda ~papi` for Perlmutter GPU partition with CUDA 11.7 and without PAPI (until the double `cuptiSubscribe` issue gets fixed)
2. `hpctoolkit ~mpi ~cuda +papi` for Perlmutter CPU partition without CUDA but with PAPI